### PR TITLE
Implement save-sync update

### DIFF
--- a/src/archive.rs
+++ b/src/archive.rs
@@ -62,7 +62,7 @@ impl Archive {
         }
     }
 
-    pub fn compress_directory<T: AsRef<Path>>(source: &T, target: &T) {
+    pub fn compress_directory<T: AsRef<Path>, U: AsRef<Path>>(source: &T, target: &U) {
         let tar_file = File::create(target).unwrap();
         let zstd_encoder = zstd::stream::Encoder::new(tar_file, 0).unwrap();
         let mut archive = TarBuilder::new(zstd_encoder);
@@ -85,7 +85,7 @@ impl Archive {
         }
     }
 
-    pub fn compress_file<T: AsRef<Path>>(source: &T, target: &T) {
+    pub fn compress_file<T: AsRef<Path>, U: AsRef<Path>>(source: &T, target: &U) {
         let mut file = File::open(source).unwrap(); // Reader
         let compressed_file = File::create(target).unwrap(); // Writer
         let mut zstd_encoder = zstd::stream::Encoder::new(compressed_file, 0).unwrap();
@@ -94,7 +94,7 @@ impl Archive {
         zstd_encoder.finish().unwrap();
     }
 
-    pub fn decompress_archive<T: AsRef<Path>>(source: &T, target: &T) {
+    pub fn decompress_archive<T: AsRef<Path>, U: AsRef<Path>>(source: &T, target: &U) {
         let source_file = File::open(source).unwrap();
         let zstd_decoder = zstd::stream::Decoder::new(source_file).unwrap();
         let mut archive = TarArchive::new(zstd_decoder);
@@ -102,7 +102,7 @@ impl Archive {
         archive.unpack(target).unwrap();
     }
 
-    pub fn decompress_file<T: AsRef<Path>>(source: &T, target: &T) {
+    pub fn decompress_file<T: AsRef<Path>, U: AsRef<Path>>(source: &T, target: &U) {
         let file = File::open(source).unwrap();
         let mut target_file = File::create(target).unwrap();
 


### PR DESCRIPTION
With this PR, a couple of things need to be considered:
* `save-sync verify` should be renamed to `save-sync check` in order to distinguish trying to verify that backups have not changed and verify that backups are still up to date. 
* `save-sync verify` and `save-sync update` need to account for deleted files (both unexpectedly in the backup folder and for game save files that no longer exist). Right now they are unaccounted for which is a rather big issue. 